### PR TITLE
Fix linkage errors on Windows.

### DIFF
--- a/lib/lodepng/CMakeLists.txt
+++ b/lib/lodepng/CMakeLists.txt
@@ -10,4 +10,4 @@ endif ()
 set(CMAKE_CXX_STANDARD 11)
 
 include_directories(include)
-add_library(lodepng picopng.cpp include/lodepng/picopng.h)
+add_library(lodepng SHARED STATIC picopng.cpp include/lodepng/picopng.h)


### PR DESCRIPTION
Build lodepng library as STATIC and SHARED to link it in whycpp properly
on Windows and resolve 0xC0000135 error.

Signed-off-by: Kirill Leyfer <k.leyfer@drweb.com>